### PR TITLE
Deselecting achievement items should still be possible

### DIFF
--- a/src/main/webapp/app/shared/achievement/item/achievement-item.component.ts
+++ b/src/main/webapp/app/shared/achievement/item/achievement-item.component.ts
@@ -66,8 +66,8 @@ export class AchievementItemComponent {
         event.preventDefault();
         event.stopPropagation();
         this.inEditMode = false;
+        this.onItemSelected.emit(this.item);
         if (!this._active) {
-            this.onItemSelected.emit(this.item);
             if (!this.popover.isOpen()) {
                 this.popover.open();
             }


### PR DESCRIPTION
This is a regression of implementing the popover for editing multiplicators