### PR TITLE
[EDO-257] Reorder team page layout by making skills more prominent

### DIFF
--- a/src/main/webapp/app/teams/teams-achievements.scss
+++ b/src/main/webapp/app/teams/teams-achievements.scss
@@ -3,6 +3,9 @@
 @import '../../content/scss/mixins';
 
 .teams-achievements {
+    h4 {
+        color: $dojo-text-primary;
+    }
     .achievement-container {
         /deep/ .simplebar-scroll-content {
             padding-right: 1.94em !important;

--- a/src/main/webapp/app/teams/teams-achievements.scss
+++ b/src/main/webapp/app/teams/teams-achievements.scss
@@ -4,18 +4,14 @@
 
 .teams-achievements {
     .achievement-container {
-        /deep/ .simplebar-track {
-            bottom: 1em !important;
-        }
         /deep/ .simplebar-scroll-content {
             padding-right: 1.94em !important;
             .simplebar-content {
-                margin-right: -0.69em !important;
+                padding: 5px;
             }
         }
         @include accordion();
         height: inherit;
-        padding-right: 10px;
         .achievement-list {
         }
         &-body {
@@ -28,8 +24,7 @@
 @media only screen and (min-width: map-get($grid-breakpoints, lg)) {
     .teams-achievements {
         .achievement-container {
-            height: calc(100vh - 242px);
-            padding: 5px;
+            height: calc(100vh - 188px);
         }
         /deep/ .card-header,
         /deep/ .achievement-list-header .achievement-list-header-left .achievement-item {

--- a/src/main/webapp/app/teams/teams-skills.component.html
+++ b/src/main/webapp/app/teams/teams-skills.component.html
@@ -34,7 +34,7 @@
                         <div class="d-flex flex-column justify-content-between skill-text">
                             <div class="d-flex flex-column mb-1">
                                 <div class="skill-title">
-                                    <a (click)="handleSkillClicked(skill)">{{skill.title | truncateString: 80}}</a>
+                                    <a class="text-dark" (click)="handleSkillClicked(skill)">{{skill.title | truncateString: 80}}</a>
                                 </div>
                                 <div class="skill-description">
                                     <a (click)="handleSkillClicked(skill)">{{skill.description | truncateString: 240}}</a>

--- a/src/main/webapp/app/teams/teams-skills.component.html
+++ b/src/main/webapp/app/teams/teams-skills.component.html
@@ -29,9 +29,9 @@
             <div class="list-group-item list-group-item-action flex-column align-items-start mb-3 skill-list-item"
                 [ngClass]="{'active-skill':isActiveSkill(skill), 'irrelevant-skill': skill.irrelevant, 'in-skill-details': isInSkillDetails()}"
                 *ngFor="let skill of skills | skillFilter:search | skillSort:orderBy">
-                <div class="d-flex flex-column">
-                    <div class="d-flex">
-                        <div class="skill-title d-flex flex-column" [ngClass]="{'irrelevant': skill.irrelevant}">
+                <div class="d-flex flex-column justify-content-between h-100">
+                    <div class="d-flex flex-grow-1">
+                        <div class="skill-title d-flex flex-column justify-content-between" [ngClass]="{'irrelevant': skill.irrelevant}">
                             <div class="d-flex flex-row" (click)="handleSkillClicked(skill)">
                                 <a *ngIf="isInSkillDetails()" class="mb-1">{{skill.title}}</a>
                                 <a *ngIf="!isInSkillDetails()"

--- a/src/main/webapp/app/teams/teams-skills.component.html
+++ b/src/main/webapp/app/teams/teams-skills.component.html
@@ -24,9 +24,9 @@
             </div>
         </div>
     </div>
-    <div>
-        <div class="teams-skills-list list-group" data-simplebar="init">
-            <li class="list-group-item list-group-item-action flex-column align-items-start mb-3 skill-list-item"
+    <div class="teams-skills-list list-group" data-simplebar="init">
+        <div class="d-flex flex-row flex-wrap">
+            <div class="list-group-item list-group-item-action flex-column align-items-start mb-3 skill-list-item"
                 [ngClass]="{'active-skill':isActiveSkill(skill), 'irrelevant-skill': skill.irrelevant, 'in-skill-details': isInSkillDetails()}"
                 *ngFor="let skill of skills | skillFilter:search | skillSort:orderBy">
                 <div class="d-flex flex-column">
@@ -124,7 +124,7 @@
                         </div>
                     </div>
                 </div>
-            </li>
+            </div>
         </div>
     </div>
 </div>

--- a/src/main/webapp/app/teams/teams-skills.component.html
+++ b/src/main/webapp/app/teams/teams-skills.component.html
@@ -30,13 +30,15 @@
                 [ngClass]="{'active-skill':isActiveSkill(skill), 'irrelevant-skill': skill.irrelevant, 'in-skill-details': isInSkillDetails()}"
                 *ngFor="let skill of skills | skillFilter:search | skillSort:orderBy">
                 <div class="d-flex flex-column justify-content-between h-100">
-                    <div class="d-flex flex-grow-1">
-                        <div class="skill-title d-flex flex-column justify-content-between" [ngClass]="{'irrelevant': skill.irrelevant}">
-                            <div class="d-flex flex-row" (click)="handleSkillClicked(skill)">
-                                <a *ngIf="isInSkillDetails()" class="mb-1">{{skill.title}}</a>
-                                <a *ngIf="!isInSkillDetails()"
-                                   (click)="goToDetails(skill)"
-                                   class="mb-1">{{skill.title}}</a>
+                    <div class="d-flex flex-grow-1 skill-info" [ngClass]="{'irrelevant': skill.irrelevant}">
+                        <div class="d-flex flex-column justify-content-between skill-text">
+                            <div class="d-flex flex-column mb-1">
+                                <div class="skill-title">
+                                    <a (click)="handleSkillClicked(skill)">{{skill.title | truncateString: 80}}</a>
+                                </div>
+                                <div class="skill-description">
+                                    <a (click)="handleSkillClicked(skill)">{{skill.description | truncateString: 240}}</a>
+                                </div>
                             </div>
                             <div class="d-flex flex-row justify-content-between align-items-center">
                                 <div>

--- a/src/main/webapp/app/teams/teams-skills.component.ts
+++ b/src/main/webapp/app/teams/teams-skills.component.ts
@@ -264,6 +264,8 @@ export class TeamsSkillsComponent implements OnInit, OnChanges {
                 });
                 this.breadcrumbService.setBreadcrumb(this.team, this.activeDimension, this.activeLevel, this.activeBadge, skill.body);
             });
+        } else {
+            this.goToDetails(s);
         }
     }
 

--- a/src/main/webapp/app/teams/teams-skills.scss
+++ b/src/main/webapp/app/teams/teams-skills.scss
@@ -4,10 +4,6 @@
 @import '../../content/scss/mixins';
 @import './skill-details/skill-details-rating/skill-details-rating';
 
-.in-skill-details {
-    cursor: pointer;
-}
-
 .irrelevant-skill {
     .skill-title {
         opacity: 0.7;
@@ -43,15 +39,6 @@
             .simplebar-content {
                 padding: 5px;
                 overflow-x: hidden;
-            }
-        }
-        .skill-title {
-            padding: 5px 5px 5px 20px;
-            word-break: break-word;
-            flex-grow: 1;
-
-            &.irrelevant {
-                opacity: 0.3;
             }
         }
 
@@ -106,6 +93,7 @@
             margin-left: 5px;
             margin-right: 5px;
             hyphens: auto;
+            overflow-wrap: anywhere;
         }
     }
 }

--- a/src/main/webapp/app/teams/teams-skills.scss
+++ b/src/main/webapp/app/teams/teams-skills.scss
@@ -104,7 +104,11 @@
         }
         .list-group-item {
             @include skill-list-entry();
+            flex: 1 1 32%;
             border: none;
+            margin-left: 5px;
+            margin-right: 5px;
+            hyphens: auto;
         }
     }
 }

--- a/src/main/webapp/app/teams/teams-skills.scss
+++ b/src/main/webapp/app/teams/teams-skills.scss
@@ -76,14 +76,9 @@
                     opacity: 0.3;
                     cursor: default;
                 }
-                i {
-                    margin-right: 3px;
-                }
-                a {
-                    small {
-                        color: $dojo-text-secondary;
-                    }
-                }
+            }
+            a.skill-action-bar-item {
+                color: $dojo-text-primary;
             }
         }
         .list-group-item {

--- a/src/main/webapp/app/teams/teams-skills.scss
+++ b/src/main/webapp/app/teams/teams-skills.scss
@@ -29,7 +29,6 @@
         color: $dojo-text-primary;
     }
 
-    padding-right: 10px;
     &-filter {
         color: $dojo-text-primary;
         margin-right: 14px;
@@ -42,10 +41,8 @@
         /deep/ .simplebar-scroll-content {
             padding-right: 1.94em !important;
             .simplebar-content {
-                padding-left: 2px !important;
-                padding-right: 5px !important;
-                margin-right: -0.69em !important;
-                overflow-x: hidden !important;
+                padding: 5px;
+                overflow-x: hidden;
             }
         }
         .skill-title {
@@ -116,9 +113,7 @@
 @media only screen and (min-width: map-get($grid-breakpoints, lg)) {
     .teams-skills {
         .teams-skills-list {
-            height: calc(100vh - 320px);
-            padding: 5px;
-            padding-left: 0;
+            height: calc(100vh - 276px);
         }
     }
 }

--- a/src/main/webapp/app/teams/teams-status.component.html
+++ b/src/main/webapp/app/teams/teams-status.component.html
@@ -5,7 +5,7 @@
                 <fa-icon icon="ellipsis-v"></fa-icon>
             </div>
             <jhi-team-image [team]="team" [hasPlaceholder]="false" [hasBorder]="false" [hasOverlay]="true"
-                            [showExpiredLabel]="false" size="35vh" imageSize="large">
+                            [showExpiredLabel]="false" size="18vw" imageSize="large">
             </jhi-team-image>
         </div>
         <div class="avatar-image-wrapper d-flex align-self-center">
@@ -28,7 +28,7 @@
             </div>
         </div>
     </div>
-    <div data-simplebar class="teams-status-achievements-container">
+    <div data-simplebar class="teams-status-achievements-container mt-3">
         <div class="teams-status-achievements">
             <div class="teams-status-achievements-levels d-flex flex-wrap justify-content-center mb-1">
                 <div class="mx-2" *ngFor="let highestLevel of highestAchievedLevels">

--- a/src/main/webapp/app/teams/teams-status.component.html
+++ b/src/main/webapp/app/teams/teams-status.component.html
@@ -31,12 +31,12 @@
     <div data-simplebar class="teams-status-achievements-container mt-3">
         <div class="teams-status-achievements">
             <div class="teams-status-achievements-levels d-flex flex-wrap justify-content-center mb-1">
-                <div class="mx-2" *ngFor="let highestLevel of highestAchievedLevels">
+                <div class="mx-2 mb-2" *ngFor="let highestLevel of highestAchievedLevels">
                     <div>
                         <div class="d-flex justify-content-center">
-                            <h5>{{highestLevel.dimension.name}}</h5>
+                            <h6 class="mb-0">{{highestLevel.dimension.name}}</h6>
                         </div>
-                        <div class="d-flex d-inline-flex">
+                        <div class="d-flex">
                             <jhi-achievement-item [item]="highestLevel.level" type="item-level" [hasStatus]="false"
                                                   [active]="false"
                                                   (onItemSelected)="selectItem('level', highestLevel.level.id)"></jhi-achievement-item>

--- a/src/main/webapp/app/teams/teams-status.scss
+++ b/src/main/webapp/app/teams/teams-status.scss
@@ -2,16 +2,15 @@
 .teams-status {
     height: inherit;
     position: relative;
-    overflow-y: hidden;
-    padding-right: 10px;
     .teams-status-avatar {
+        height: 25vw;
         text-align: center;
         .team-logo-wrapper {
             position: relative;
         }
         .avatar-image-wrapper {
-            width: 31vh;
-            height: 41vh;
+            width: 18vw;
+            height: 20vw;
             position: absolute;
             top: 0.5rem;
             .avatar-image {
@@ -28,34 +27,34 @@
         }
         .status-meta {
             width: 100%;
-            height: 20vh;
+            height: 7vw;
             position: relative;
-            margin-top: -4vh;
+            margin-top: -2vw;
             color: $dojo-text-inverse-secondary;
             &-text {
                 position: absolute;
-                top: 8vh;
+                top: 3vw;
                 z-index: 4;
                 h5 {
-                    font-size: calc(10px + 1.4vh);
+                    font-size: calc(10px + 0.8vw);
                 }
                 h6 {
-                    font-size: calc(6px + 0.8vh);
+                    font-size: calc(6px + 0.4vw);
                 }
                 .team-title-with-slogan {
-                    margin-top: -1vh;
+                    margin-top: -0.5vw;
                 }
                 .team-score {
-                    font-size: calc(10px + 1vh);
+                    font-size: calc(10px + 0.6vw);
                     z-index: 4;
                     &::before {
                         content: '';
-                        width: calc(10px + 1vh);
-                        height: calc(10px + 1vh);
+                        width: calc(10px + 0.6vw);
+                        height: calc(10px + 0.6vw);
                         position: absolute;
                         background: no-repeat center/contain url('../../content/images/coin.png');
-                        margin-top: calc(2px + 0.2vh);
-                        margin-left: calc(-12px - 1.2vh);
+                        margin-top: calc(2px + 0.1vw);
+                        margin-left: calc(-12px - 0.6vw);
                         z-index: 4;
                     }
                 }
@@ -64,10 +63,7 @@
                 content: '';
                 width: inherit;
                 height: inherit;
-                max-width: 50vh;
-                min-width: 100%;
-                min-height: 90px;
-                max-height: 16vh;
+                min-width: 120%;
                 position: absolute;
                 background: no-repeat center/contain url('../../content/images/brushstroke.png');
                 z-index: 2;
@@ -76,16 +72,17 @@
     }
 
     .teams-status-achievements-container {
-        height: 29vh;
+        height: calc(82vh - 25vw);
     }
 
     .team-edit-btn {
         cursor: pointer;
         position: absolute;
-        right: -5rem;
+        right: 0;
         top: 10px;
         font-size: 1.3em;
         color: #777;
+        z-index: 2;
         &:hover {
             color: #000;
         }

--- a/src/main/webapp/app/teams/teams.component.html
+++ b/src/main/webapp/app/teams/teams.component.html
@@ -4,17 +4,17 @@
     </div>
 </div>
 <div class="row teams">
-    <div class="col-lg-6">
-        <jhi-teams-status [team]="team" [teamSkills]="teamSkills" [badges]="badges" [skills]="skills"></jhi-teams-status>
-    </div>
-    <div class="col-lg-6">
+    <div class="col-xl-6 col-lg-8">
         <div class="row">
-            <div class="col-lg-7">
+            <div class="col-xl-5 col-lg-6">
+                <jhi-teams-status [team]="team" [teamSkills]="teamSkills" [badges]="badges" [skills]="skills"></jhi-teams-status>
+            </div>
+            <div class="col-xl-7 col-lg-6">
                 <jhi-teams-achievements [team]="team" [teamSkills]="teamSkills" [badges]="badges" [skills]="skills"></jhi-teams-achievements>
             </div>
-            <div class="col-lg-5">
-                <jhi-teams-skills [iSkills]="skills" [team]="team" (onSkillChanged)="loadTeamSkills()"></jhi-teams-skills>
-            </div>
         </div>
+    </div>
+    <div class="col-xl-6 col-lg-4">
+        <jhi-teams-skills [iSkills]="skills" [team]="team" (onSkillChanged)="loadTeamSkills()"></jhi-teams-skills>
     </div>
 </div>

--- a/src/main/webapp/app/teams/teams.scss
+++ b/src/main/webapp/app/teams/teams.scss
@@ -1,6 +1,6 @@
 @import '~bootstrap/scss/bootstrap';
 
-@media only screen and (min-width: map-get($grid-breakpoints, lg)) {
+@media only screen and (min-width: map-get($grid-breakpoints, xl)) {
     .teams {
         height: calc(100vh - 151px);
         overflow: hidden;

--- a/src/main/webapp/content/scss/mixins.scss
+++ b/src/main/webapp/content/scss/mixins.scss
@@ -29,6 +29,7 @@
                 font-size: 0.73em;
                 a {
                     color: $dojo-text-primary;
+                    white-space: pre-wrap;
                 }
             }
             .skill-title,

--- a/src/main/webapp/content/scss/mixins.scss
+++ b/src/main/webapp/content/scss/mixins.scss
@@ -13,7 +13,7 @@
         background: #f0f0f0;
     }
     a {
-        color: $dojo-text-primary;
+        color: $dojo-text-secondary;
         font-weight: normal;
     }
     * {
@@ -25,11 +25,11 @@
         }
         .skill-text {
             padding: 5px 5px 5px 10px;
-            .skill-title {
-                color: initial;
-            }
             .skill-description {
                 font-size: 0.73em;
+                a {
+                    color: $dojo-text-primary;
+                }
             }
             .skill-title,
             .skill-description {

--- a/src/main/webapp/content/scss/mixins.scss
+++ b/src/main/webapp/content/scss/mixins.scss
@@ -1,7 +1,6 @@
 @mixin skill-list-entry() {
     padding: 0;
     outline: none;
-    cursor: pointer;
     background-color: $dojo-bg-gradient-from;
     border-radius: 2px;
     @include shadow();
@@ -19,6 +18,24 @@
     }
     * {
         outline: none;
+    }
+    .skill-info {
+        &.irrelevant {
+            opacity: 0.3;
+        }
+        .skill-text {
+            padding: 5px 5px 5px 10px;
+            .skill-title {
+                color: initial;
+            }
+            .skill-description {
+                font-size: 0.73em;
+            }
+            .skill-title,
+            .skill-description {
+                cursor: pointer;
+            }
+        }
     }
 }
 @mixin achievement-image() {


### PR DESCRIPTION
Skills should be put more in focus when visiting the team page as a member that wants to tick off skills. With this PR come some improvements around simplebar (custom scroll bar) styling within both overview and team pages.