### PR TITLE
[EDO-262] Trainings are missing from skill details view

### DIFF
--- a/src/main/webapp/app/shared/common.resolver.ts
+++ b/src/main/webapp/app/shared/common.resolver.ts
@@ -16,9 +16,6 @@ import { filter, map, take } from 'rxjs/operators';
 import { IOrganization } from 'app/shared/model/organization.model';
 import { HttpResponse } from '@angular/common/http';
 import { OrganizationService } from 'app/entities/organization';
-import { mergeMap } from 'rxjs/operators';
-import { ServerInfoService } from 'app/server-info';
-import { IServerInfo } from 'app/shared/model/server-info.model';
 import { DimensionService } from 'app/entities/dimension';
 
 @Injectable()
@@ -186,7 +183,7 @@ export class AllCommentsResolve implements Resolve<any> {
 
 @Injectable()
 export class SkillResolve implements Resolve<any> {
-    constructor(private skillService: SkillService, private serverInfoService: ServerInfoService, private router: Router) {}
+    constructor(private skillService: SkillService, private router: Router) {}
 
     resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
         const skillId = route.params['skillId'] ? route.params['skillId'] : null;
@@ -206,12 +203,10 @@ export class SkillResolve implements Resolve<any> {
 
 @Injectable()
 export class AllTrainingsResolve implements Resolve<any> {
-    constructor(private trainingService: TrainingService, private serverInfoService: ServerInfoService) {}
+    constructor(private trainingService: TrainingService) {}
 
     resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
-        return this.serverInfoService
-            .query()
-            .pipe(mergeMap((serverInfo: IServerInfo) => this.trainingService.query({ 'validUntil.greaterThan': serverInfo.time })));
+        return this.trainingService.query();
     }
 }
 

--- a/src/main/webapp/app/shared/skill-details/skill-details-info.component.ts
+++ b/src/main/webapp/app/shared/skill-details/skill-details-info.component.ts
@@ -19,6 +19,8 @@ import { ITraining } from 'app/shared/model/training.model';
 import { NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 import { TrainingsAddComponent } from 'app/shared/trainings/trainings-add.component';
 import { SkillStatus, SkillStatusUtils } from 'app/shared/model/skill-status';
+import { ServerInfoService } from 'app/server-info';
+import { IServerInfo } from 'app/shared/model/server-info.model';
 
 @Component({
     selector: 'jhi-skill-details-info',
@@ -62,7 +64,8 @@ export class SkillDetailsInfoComponent implements OnInit, OnChanges {
         private route: ActivatedRoute,
         private teamSkillsService: TeamSkillService,
         private teamsSelectionService: TeamsSelectionService,
-        private modalService: NgbModal
+        private modalService: NgbModal,
+        private serverInfoService: ServerInfoService
     ) {}
 
     ngOnInit(): void {
@@ -95,7 +98,13 @@ export class SkillDetailsInfoComponent implements OnInit, OnChanges {
         this.neededForBadges = this._badges.filter((badge: IBadge) =>
             this._badgeSkills.some((badgeSkill: IBadgeSkill) => badge.id === badgeSkill.badgeId && badgeSkill.skillId === this.skill.id)
         );
-        this.trainings = (this._allTrainings || []).filter(training => (training.skills || []).find(skill => skill.id === this.skill.id));
+        this.serverInfoService.query().subscribe((serverInfo: IServerInfo) => {
+            this.trainings = (this._allTrainings || []).filter(
+                training =>
+                    (training.skills || []).find(skill => skill.id === this.skill.id) &&
+                    (training.validUntil === null || training.validUntil > moment(serverInfo.time))
+            );
+        });
     }
 
     onVoteSubmittedFromChild(vote: ISkillRate) {

--- a/src/main/webapp/app/shared/skill-details/skill-details-info.component.ts
+++ b/src/main/webapp/app/shared/skill-details/skill-details-info.component.ts
@@ -82,7 +82,9 @@ export class SkillDetailsInfoComponent implements OnInit, OnChanges {
     }
 
     ngOnChanges(changes: SimpleChanges) {
-        this.loadData();
+        if (!changes.skill) {
+            this.loadData();
+        }
     }
 
     loadData() {


### PR DESCRIPTION
When adding and linking trainings to skills, they should appear in team skill details and overview skill details. This is currently not the case and manifesting as "No helpful trainings available".